### PR TITLE
Identify tenant even if class name is nonstandard.

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -3,7 +3,7 @@ module MultiTenant
     DEFAULT_ID_FIELD = 'id'.freeze
 
     def multi_tenant(tenant_name, options = {})
-      if to_s.underscore.to_sym == tenant_name
+      if to_s.underscore.to_sym == tenant_name || (!table_name.nil? && table_name.singularize.to_sym == tenant_name)
         unless MultiTenant.with_write_only_mode_enabled?
           # This is the tenant model itself. Workaround for https://github.com/citusdata/citus/issues/687
           before_create -> do

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -70,6 +70,24 @@ describe MultiTenant do
     it { expect(@partition_key_not_model_task.non_model_id).to be 77 }
   end
 
+
+  describe 'Tenant model with a nonstandard class name' do
+    let(:account_klass) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'account'
+        def self.name
+          'UserAccount'
+        end
+
+        multi_tenant(:account)
+      end
+    end
+    it "does not register the tenant model" do
+      expect(MultiTenant).not_to receive(:register_multi_tenant_model)
+      account_klass
+    end
+  end
+
   describe 'Changes table_name after multi_tenant called' do
     before do
       account_klass.has_many(:posts, anonymous_class: post_klass)


### PR DESCRIPTION
Our class names are nothing like standard rails models and so the tenant model wasn't being detected here. Add an additional check for table_name attribute when determining if a model is or is not the tenant. 
